### PR TITLE
TECH-1069 Remove ps-db-crd chart from crd-charts

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -141,11 +141,6 @@ releases:
     version: 2.7.0
     <<: *defaults
 
-  - name: ps-db
-    chart: percona/ps-db
-    version: 0.10.0
-    <<: *defaults
-
   - name: psmdb-db
     chart: percona/psmdb-db
     version: 1.20.1


### PR DESCRIPTION
The chart is empty, and also not installed anywhere. The upstream chart ps-db provides percona mysql setup, which we are not using.