### PR TITLE
[PLAT-568] fix: repoint sealed-secrets chart repo to live upstream index (dead bitnami-labs 404)

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,6 +1,6 @@
 repositories:
   - name: bitnami-labs
-    url: https://bitnami-labs.github.io/sealed-secrets
+    url: https://bitnami.github.io/sealed-secrets
   - name: eks
     url: https://aws.github.io/eks-charts
   - name: karpenter


### PR DESCRIPTION
## Problem
`Fetch and Release Charts` (the chart-publish workflow) has been **failing for ~28 days** (last success 28d ago). Root cause: the publish step runs `helmfile repos`, and `helm repo add bitnami-labs https://bitnami-labs.github.io/sealed-secrets` returns **404** — the sealed-secrets project relocated its Helm chart index to `https://bitnami.github.io/sealed-secrets`. One dead repo fails the whole step, so **no CRD charts publish at all** (karpenter, trivy-operator, aws-load-balancer-controller, alloy included). This silently gates the weekly downstream Renovate CRD bumps.

## Fix (URL only — deliberately minimal)
```diff
   - name: bitnami-labs
-    url: https://bitnami-labs.github.io/sealed-secrets
+    url: https://bitnami.github.io/sealed-secrets
```
Repo alias, chart path (`bitnami-labs/sealed-secrets`) and version (`2.18.6`) are **unchanged**, so the published CRD chart keeps its exact name+version `bitnami-labs-sealed-secrets-crds@2.18.6`. The `sealed-secrets-crds` consumers in observability/devtools/platform are therefore **unaffected**.

New index confirmed live (HTTP 200) and still carries 2.18.6.

## Not in scope
The sealed-secrets **controller** already runs from DHI (`portswigger/dhi-sealed-secrets-chart`) in every cluster repo — no bitnami at runtime. This repo only uses the upstream chart to *extract the SealedSecret CRD* at build time. Fully removing the build-time bitnami reference would rename the published CRD chart and require a coordinated update of the downstream `sealed-secrets-crds` references — tracked separately, not needed to unblock.

## Validation
crd-charts CI is CodeQL/Analyze only; the publish job runs on merge to main. Will confirm `Fetch and Release Charts` goes green post-merge, then dispatch downstream Renovate.

Ref: PLAT-568.