### PR TITLE
Add Compass component descriptor

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,13 @@
+name: crd-charts
+id: 'ari:cloud:compass:ca53ac44-e1d5-4f18-9b78-0cfa4ea53aa9:component/5a457f06-865e-415d-9c51-e5e2eff545dd/80a93b13-6e09-4e03-824e-f95e9da796b0'
+slug: crd-charts
+configVersion: 1
+typeId: CLOUD_RESOURCE
+ownerId: 'ari:cloud:identity::team/793aa195-1b2d-44e4-8fd5-6aa1f3c273e9'
+fields:
+  lifecycle: Active
+  tier: 3
+  isMonorepoProject: false
+links:
+  - type: REPOSITORY
+    url: 'https://github.com/portswigger-cloud/crd-charts'


### PR DESCRIPTION
Adds `compass.yml` so this repo's Compass component is defined as code rather than drifting from an auto-import.

Sets `typeId`, `ownerId` (Technology), and the built-in `lifecycle` / `tier` fields.

**Why:** Compass currently types every platform repo as `SERVICE` regardless of what it actually is, so activity and deployment scorecards fire on repos where "no commits/deploys this month" is meaningless — config stores, docs, legacy. Typing and tiering them correctly is what lets those criteria be scoped sensibly.

Source of truth: the platform repo audit — `Kind` maps to `typeId`, criticality to `tier`, `Status` to `lifecycle`.
