### PR TITLE
Add description to Compass descriptor

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,6 +1,7 @@
 name: crd-charts
 id: 'ari:cloud:compass:ca53ac44-e1d5-4f18-9b78-0cfa4ea53aa9:component/5a457f06-865e-415d-9c51-e5e2eff545dd/80a93b13-6e09-4e03-824e-f95e9da796b0'
 slug: crd-charts
+description: 'Helm charts for managing of CRDs for common helm applications'
 configVersion: 1
 typeId: CLOUD_RESOURCE
 ownerId: 'ari:cloud:identity::team/793aa195-1b2d-44e4-8fd5-6aa1f3c273e9'


### PR DESCRIPTION
Restores the component `description` in `compass.yml`.

The previous descriptor omitted `description`. Compass config-as-code is authoritative, so merging it blanked the description on the component. This sets it back, sourced from the GitHub repo description (which is what Compass originally imported it from).

No other field changes.
